### PR TITLE
instrumented nested loop

### DIFF
--- a/train.py
+++ b/train.py
@@ -258,7 +258,7 @@ def train_model(model, trainloaders, valloaders, test1loaders, test2loaders,
             running_corrects = 0
             # Iterate over data.
             model.train()
-            for inputs, labels in tqdm(trainloaders):
+            for inputs, labels in flor.loop("batch", trainloaders):
                 inputs = inputs.to(device)
                 labels = labels.to(device)
                 


### PR DESCRIPTION
Instrumented the nested training loop with `flor.loop`. This is so during replay it is possible to skip this GPU-intensive code and instead load the end state from checkpoint. This should also add checkpoints in your `~/.flor/` directory.

Your use elucidates a FlorDB extension for checkpointing single-loops (see this [issue](https://github.com/ucbrise/flor/issues/135)) but in this case, I think the right thing to do is instrument the outer and nested loop.

Thanks!